### PR TITLE
Fixes 'module object is not callable' error

### DIFF
--- a/bin/clustervars
+++ b/bin/clustervars
@@ -15,7 +15,7 @@ import cluster_linfreq
 import clustermaker
 from resultserializer import Results
 import util
-from progressbar import progressbar
+import tqdm
 
 def _convert_assignment_to_clustering(Z, vids):
   uniq_Z  = set(list(Z))
@@ -83,7 +83,7 @@ def _launch_parallel(run_chain, args, iter_per_chain, nchains, parallel, seed):
   manager = multiprocessing.Manager()
   progress_queue = manager.Queue()
 
-  with progressbar(total=total, desc='Clustering variants', unit='iter', dynamic_ncols=True) as pbar:
+  with tqdm.tqdm(total=total, desc='Clustering variants', unit='iter', dynamic_ncols=True) as pbar:
     with concurrent.futures.ProcessPoolExecutor(max_workers=parallel) as ex:
       for C in range(nchains):
         jobs.append(ex.submit(run_chain, *args, seed + C + 1, progress_queue))

--- a/lib/pairwise.py
+++ b/lib/pairwise.py
@@ -1,7 +1,7 @@
 import numpy as np
 import scipy.special
 import concurrent.futures
-from progressbar import progressbar
+import tqdm
 import itertools
 
 from common import Models, NUM_MODELS, ALL_MODELS
@@ -158,7 +158,7 @@ def calc_posterior(variants, logprior, rel_type, parallel=1):
   )
 
   if parallel > 0:
-    with progressbar(total=len(pairs), desc='Computing %s relations' % rel_type, unit='pair', dynamic_ncols=True) as pbar:
+    with tqdm.tqdm(total=len(pairs), desc='Computing %s relations' % rel_type, unit='pair', dynamic_ncols=True) as pbar:
       posterior, evidence =_compute(pbar)
   else:
     posterior, evidence =_compute(None)

--- a/lib/tree_sampler.py
+++ b/lib/tree_sampler.py
@@ -2,7 +2,7 @@ import numpy as np
 import scipy.stats
 import common
 import mutrel
-from progressbar import progressbar
+import tqdm
 import phi_fitter
 import hyperparams as hparams
 import math
@@ -599,7 +599,7 @@ def sample_trees(data_mutrel, supervars, superclusters, trees_per_chain, burnin,
     # the main process to update the progress bar.
     progress_queue = manager.Queue()
 
-    with progressbar(total=total, desc='Sampling trees', unit='tree', dynamic_ncols=True) as pbar:
+    with tqdm.tqdm(total=total, desc='Sampling trees', unit='tree', dynamic_ncols=True) as pbar:
       with concurrent.futures.ProcessPoolExecutor(max_workers=parallel) as ex:
         for C in range(nchains):
           # Ensure each chain's random seed is different from the seed used to


### PR DESCRIPTION
Fixes https://github.com/morrislab/pairtree/issues/7 by replacing the `progressbar` module and `progressbar` calls with `tqdm`.