### PR TITLE
Fixes divide by zero exception when omega=0

### DIFF
--- a/lib/phi_fitter_lol.py
+++ b/lib/phi_fitter_lol.py
@@ -42,9 +42,16 @@ def _fit_etas(adj, A, ref_reads, var_reads, omega, method, iterations, parallel,
   # Numba only supports dot products on float arrays, not int arrays.
   A = A.astype(np.float64)
   Z = Z.astype(np.float64)
+  
+  # we want to operate on float arrays when computing phi_implied 
+  var_reads = var_reads.astype(np.float64)
+  ref_reads = ref_reads.astype(np.float64)
 
   if isinstance(eta_init, str) and eta_init == 'mle':
-    phi_implied = (var_reads / (ref_reads + var_reads)) / omega
+
+    # To prevent the true_divide error, we use numpy divide with the condition to only perform division if omega and var_reads are not zero.
+    tmp_vaf = np.divide(var_reads, (ref_reads + var_reads), out=np.zeros_like(var_reads), where=var_reads!=0)
+    phi_implied = np.divide(tmp_vaf, omega, out=np.zeros_like(tmp_vaf), where=omega!=0)
     phi_implied = np.minimum(1, phi_implied)
     phi_implied = np.maximum(0, phi_implied)
     # Make first row 1 to account for normal root.

--- a/lib/phi_fitter_projection.py
+++ b/lib/phi_fitter_projection.py
@@ -24,13 +24,14 @@ def _convert_adjm_to_adjlist(adjm):
 
 def fit_etas(adj, superclusters, supervars):
   svids = common.extract_vids(supervars)
-  R = np.array([supervars[svid]['ref_reads'] for svid in svids])
-  V = np.array([supervars[svid]['var_reads'] for svid in svids])
+  R = np.array([supervars[svid]['ref_reads'] for svid in svids], dtype=np.float64)
+  V = np.array([supervars[svid]['var_reads'] for svid in svids], dtype=np.float64)
   T = R + V
-  omega = np.array([supervars[svid]['omega_v'] for svid in svids])
+  omega = np.array([supervars[svid]['omega_v'] for svid in svids], dtype=np.float64)
   M, S = T.shape
 
-  phi_hat = V / (omega * T)
+  # To prevent the true_divide error, we use numpy divide with the condition to only perform division if omega * T is not zero.
+  phi_hat = np.divide(V, omega * T, out=np.zeros_like(V), where=(omega * T)!=0)
   phi_hat = np.maximum(0, phi_hat)
   phi_hat = np.minimum(1, phi_hat)
   phi_hat = np.insert(phi_hat, 0, 1, axis=0)


### PR DESCRIPTION
Minimal changes necessary to fix divide by zero error that occurs when a mutations var_read_prob is equal to 0. Issue arises when fitting etas using both rprop and projection algorithms. See issue #14. 