### PR TITLE
Updating multiprocessing.set_start_method() function calls

### DIFF
--- a/bin/clustervars
+++ b/bin/clustervars
@@ -264,5 +264,12 @@ def main():
     json.dump(params, F)
 
 if __name__ == '__main__':
-  multiprocessing.set_start_method('fork')
+  # This is default on Unix but not macOS. Without this, resources aren't
+  # inherited by subprocesses on macOS and various things break. However, on
+  # macOS, it can cause crashes. See
+  # https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
+  # On top of this, MacOS throws an exception since set_start_method is called elsewhere, 
+  # adding the argument 'force=True' resolves the exception.
+  if sys.platform == "darwin":
+    multiprocessing.set_start_method('fork', force=True)
   main()

--- a/bin/pairtree
+++ b/bin/pairtree
@@ -170,5 +170,8 @@ if __name__ == '__main__':
   # inherited by subprocesses on macOS and various things break. However, on
   # macOS, it can cause crashes. See
   # https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
-  multiprocessing.set_start_method('fork')
+  # On top of this, MacOS throws an exception since set_start_method is called elsewhere, 
+  # adding the argument 'force=True' resolves the exception.
+  if sys.platform == "darwin":
+    multiprocessing.set_start_method('fork', force=True)
   main()

--- a/bin/plotvars
+++ b/bin/plotvars
@@ -88,5 +88,12 @@ def main():
     write_footer(outf)
 
 if __name__ == '__main__':
-  multiprocessing.set_start_method('fork')
+  # This is default on Unix but not macOS. Without this, resources aren't
+  # inherited by subprocesses on macOS and various things break. However, on
+  # macOS, it can cause crashes. See
+  # https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
+  # On top of this, MacOS throws an exception since set_start_method is called elsewhere, 
+  # adding the argument 'force=True' resolves the exception.
+  if sys.platform == "darwin":
+    multiprocessing.set_start_method('fork', force=True)
   main()

--- a/bin/removegarbage
+++ b/bin/removegarbage
@@ -148,5 +148,12 @@ def main():
     json.dump(params, F)
 
 if __name__ == '__main__':
-  multiprocessing.set_start_method('fork')
+  # This is default on Unix but not macOS. Without this, resources aren't
+  # inherited by subprocesses on macOS and various things break. However, on
+  # macOS, it can cause crashes. See
+  # https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
+  # On top of this, MacOS throws an exception since set_start_method is called elsewhere, 
+  # adding the argument 'force=True' resolves the exception.
+  if sys.platform == "darwin":
+    multiprocessing.set_start_method('fork', force=True)
   main()


### PR DESCRIPTION
Obtaining  error on MacOS from the call `multiprocessing.set_start_method()` stating that the context has already been set.

Solution is to add the argument `force=True` to the `multiprocessing.set_start_method()`.

Added condition to only call `multiprocessing.set_start_method()` when the OS is MacOS. 

Verified everything still works properly on MacOS and Linux.

